### PR TITLE
Fixed hard-to-find lua files and added Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROGNAME=sosi2osm
 OBJFILES=sosi2osm.o sosi.o tag.o node.o
 
-CPPFLAGS = -I /usr/local/include/fyba/ `pkg-config --cflags lua5.1-c++` -DLINUX -DUNIX -g
+CPPFLAGS = -I/usr/local/include/fyba -I/usr/include/fyba/ `pkg-config --cflags lua5.1-c++` -DLINUX -DUNIX -g
 LDFLAGS = -lfyba -lfygm -lfyut -lproj `pkg-config --libs lua5.1-c++`
 
 all: $(PROGNAME)
@@ -11,3 +11,16 @@ clean:
 
 $(PROGNAME): $(OBJFILES)
 	$(CXX) $^ $(LDFLAGS) -o $@
+
+install: sosi2osm
+	install -m 0755 sosi2osm /usr/local/bin
+	mkdir -p /usr/local/share/sosi2osm/lua
+	install -m 0644 lua/*.lua /usr/local/share/sosi2osm/lua
+
+uninstall:
+	rm /usr/local/share/sosi2osm/lua/*.lua
+	rmdir /usr/local/share/sosi2osm/lua
+	rmdir /usr/local/share/sosi2osm
+	rm /usr/local/bin/sosi2osm
+
+.PHONY: install uninstall clean all

--- a/sosi2osm.cpp
+++ b/sosi2osm.cpp
@@ -6,7 +6,7 @@
 char* execname;
 
 void usage() {
-    printf("Usage: sosi2osm [sosi file] [lua file]\n");
+    fprintf(stderr,"Usage: sosi2osm [sosi file] [lua file]\n");
 }
 
 void handleHead() {

--- a/tag.cpp
+++ b/tag.cpp
@@ -33,23 +33,84 @@ char* toUTF8(char* in, char* outBuf, size_t outlen) {
 
 lua_State *state;
 void loadLua(char* filename) {
+    FILE *file_exist_check;
+    int r;
     state = luaL_newstate();
     luaL_openlibs(state);
     
-    char library_filename[256];
-    snprintf(library_filename, 256, "%s/lua/sosi2osm.lua", dirname(execname));
-    
-    int r = luaL_loadfile(state, library_filename);
-    if (r) {
-        fprintf(stderr, "Failed to load lua library file %s\n", library_filename);
-        exit(1);
+    char filename_string[256];
+    snprintf(filename_string, 256, "%s/lua/sosi2osm.lua", dirname(execname));
+    if(file_exist_check = fopen(filename_string, "r")){
+        fclose(file_exist_check);
+        r = luaL_loadfile(state, filename_string);
+        if (r) {
+            fprintf(stderr, "Failed to load lua library file %s\n", filename_string);
+            exit(1);
+        }
     }
+    else {
+        snprintf(filename_string, 256, "/usr/local/share/sosi2osm/lua/sosi2osm.lua");
+        if(file_exist_check = fopen(filename_string, "r")){
+            fclose(file_exist_check);
+            r = luaL_loadfile(state, filename_string);
+            if (r) {
+                fprintf(stderr, "Failed to load lua library file %s\n", filename_string);
+                exit(1);
+            }
+        }
+        else {
+            snprintf(filename_string, 256, "/usr/share/sosi2osm/lua/sosi2osm.lua");
+            if(file_exist_check = fopen(filename_string, "r")){
+                fclose(file_exist_check);
+                r = luaL_loadfile(state, filename_string);
+                if (r) {
+                    fprintf(stderr, "Failed to load lua library file %s\n", filename_string);
+                    exit(1);
+                }
+                
+            }
+            else {
+                fprintf(stderr, "Could not find sosi2osm.lua. It has to be installed in /usr/share/sosi2osm/lua/ or /usr/local/share/sosi2osm/lua/\n");
+                exit(1);
+            }
+        }
+    }
+    
     lua_call(state, 0, 0);
     
-    r = luaL_loadfile(state, filename);
-    if (r) {
-        fprintf(stderr, "Failed to load lua file %s\n", filename);
-        exit(1);
+    if(file_exist_check = fopen(filename, "r")) {
+        fclose(file_exist_check);
+        r = luaL_loadfile(state, filename);
+        if (r) {
+            fprintf(stderr, "Failed to load lua file %s\n", filename);
+            exit(1);
+        }
+    }
+    else {
+        snprintf(filename_string, 256, "/usr/local/share/sosi2osm/lua/%s",filename);
+        if(file_exist_check = fopen(filename_string, "r")) {
+            fclose(file_exist_check);
+            r = luaL_loadfile(state, filename_string);
+            if (r) {
+                fprintf(stderr, "Failed to load lua file %s\n", filename_string);
+                exit(1);
+            }
+        }
+        else {
+            snprintf(filename_string, 256, "/usr/share/sosi2osm/lua/%s",filename);
+            if(file_exist_check = fopen(filename_string, "r")) {
+                fclose(file_exist_check);
+                r = luaL_loadfile(state, filename_string);
+                if(r) {
+                    fprintf(stderr, "Failed to load lua file %s\n", filename_string);
+                    exit(1);
+                }
+            }
+            else {
+                fprintf(stderr, "Could not find %s. It has to be installed in /usr/share/sosi2osm/lua/ or /usr/local/share/sosi2osm/lua/\n",filename);
+                exit(1);
+            }
+        }
     }
     
     


### PR DESCRIPTION
Hei, 

Jeg har jobbet litt med sosi2osm. Fint om du tar inn endringene (hvis du er fornøyd med dem)
i hovedgreina til sosi2osm.

Det er også .deb pakker tilgjengelig her https://launchpad.net/~saltmakrell/+archive/osm
og de kan installeres av Ubuntu 14.04 brukere med:
 sudo add-apt-repository ppa:saltmakrell/osm
 sudo apt-get update
 sudo apt-get install sosi2osm

Det vil også installere libfyba.

Mvh. Ruben

Commit message:

sosi2osm now looks for .lua files in /usr/local/share/sosi2osm/lua
and /usr/share/sosi2osm/lua if it cannot find the file in
./lua. This means that it is now possible to run sosi2osm from
wherever.

New Makefile target: install  - installs binary and lua files to
/usr/local/..

New Makefile target: uninstall  - removes all the files and folders
installed by install.

It looks for header files for libfyba also in /usr/include/..  now.
