### PR TITLE
Made some changes to make it compile on Mac and Ubuntu 12.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,17 @@
 PROGNAME=sosi2osm
 OBJFILES=sosi2osm.o sosi.o tag.o node.o
 
-CPPFLAGS := $(CPPFLAGS) `pkg-config --cflags lua5.1-c++ fyba` -DLINUX -DUNIX -g
-LDFLAGS := $(LDFLAGS) -lproj `pkg-config --libs lua5.1-c++ fyba`
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+# Mac settings
+	LUA = lua
+	LDFLAGS += -liconv 
+else
+	LUA = lua5.1-c++
+endif
+
+CPPFLAGS := $(CPPFLAGS) `pkg-config --cflags $(LUA) fyba` -DLINUX -DUNIX -g
+LDFLAGS := $(LDFLAGS) -lproj `pkg-config --libs $(LUA) fyba` -lfyut -lfygm
 
 all: $(PROGNAME)
 

--- a/tag.cpp
+++ b/tag.cpp
@@ -4,9 +4,11 @@
 #include <stdlib.h>
 #include <libgen.h>
 #include <iconv.h>
+extern "C" {
 #include <lua.h>
 #include <lualib.h>
 #include <lauxlib.h>
+}
 
 iconv_t charDescriptor;
 void setEncoding(char* encoding) {


### PR DESCRIPTION
For mac the pkg-config file is named lua instead of lua5.1-c++, therefore a variable is used to store this difference. libiconv is needed for mac. libfyut and libfybm is needed for both Ubuntu and Mac. Lua should also be linked as C-functions, this is needed for mac.