### PR TITLE
Use std::max from algorithm to fix build failure with GCC 6.2.

### DIFF
--- a/node.cpp
+++ b/node.cpp
@@ -1,5 +1,6 @@
 #include "sosi2osm.h"
 
+#include <algorithm>
 #include <proj_api.h>
 
 projPJ origProj, osmProj;
@@ -51,7 +52,7 @@ long createNode(double lat, double lon, short kp, FILE* output) {
     }
     
     if (lenM >= sizeM) {
-    	sizeM = max(1024, sizeM*2);
+    	sizeM = std::max(1024, sizeM*2);
     	latM = (double*)realloc(latM, sizeof(double) * sizeM);
     	lonM = (double*)realloc(lonM, sizeof(double) * sizeM);
     	kpM = (short*)realloc(kpM, sizeof(short) * sizeM);


### PR DESCRIPTION
 Lucas Nussbaum reported that sosi2osm failed to build in [Debian Bug #835717](https://bugs.debian.org/835717):
```make
g++ -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fPIE -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 `pkg-config --cflags lua5.1-c++ fyba` -DLINUX -DUNIX -g  -c -o node.o node.cpp
node.cpp: In function 'long int createNode(double, double, short int)':
node.cpp:54:31: error: 'max' was not declared in this scope
      sizeM = max(1024, sizeM*2);
                               ^
<builtin>: recipe for target 'node.o' failed
make[1]: *** [node.o] Error 1
```
This appears to have been triggered by the update to GCC 6.2, and using `std::max()` from `algorithm` resolves the issue.

This change has already been included as patch in the Debian package to fix the release critical bugreport.